### PR TITLE
Added syntax for positional-only arguments in `lookup_special` definition.

### DIFF
--- a/Lib/types.py
+++ b/Lib/types.py
@@ -112,29 +112,6 @@ except ImportError:
 
     del sys, inspect _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 
-    def lookup_special(object, name, *args):
-        """Lookup method name `name` on `object` skipping the instance
-        dictionary.
-
-        `name` must be a string. If the named special attribute does not exist,
-        `default` is returned if provided, otherwise AttributeError is raised.
-        """
-        from inspect import getattr_static
-        cls = type(object)
-        if not isinstance(name, str):
-            raise TypeError(
-                f"attribute name must be string, not '{type(name).__name__}'"
-            )
-        try:
-            descr = getattr_static(cls, name)
-        except AttributeError:
-            if args:
-                return args[0]
-            raise
-        if hasattr(descr, "__get__"):
-            return descr.__get__(object, cls)
-        return descr
-
 
 # Provide a PEP 3115 compliant mechanism for class creation
 def new_class(name, bases=(), kwds=None, exec_body=None):

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -10,6 +10,7 @@ Define names for built-in types that aren't directly accessible as a builtin.
 try:
     from _types import *
 except ImportError:
+    import inspect
     import sys
 
     def _f(): pass
@@ -79,7 +80,37 @@ except ImportError:
     # LazyImportType in pure Python cannot be guaranteed
     # without overriding the filter, so there is no fallback.
 
-    del sys, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
+    def enclose_lookup_special():
+        _sentinel = object()
+    
+        def lookup_special(object, name, default=_sentinel):
+            """Lookup method name `name` on `object` skipping the instance
+            dictionary.
+    
+            `name` must be a string. If the named special attribute does not exist,
+            `default` is returned if provided, otherwise AttributeError is raised.
+            """
+    
+            cls = type(object)
+            if not isinstance(name, str):
+                raise TypeError(
+                    f"attribute name must be string, not '{type(name).__name__}'"
+                )
+            try:
+                descr = inspect.getattr_static(cls, name)
+            except AttributeError:
+                if not default is _sentinel:
+                    return default
+                raise
+            if hasattr(descr, "__get__"):
+                return descr.__get__(object, cls)
+            return descr
+    
+        return lookup_special
+
+    lookup_special = enclose_lookup_special()
+
+    del sys, inspect _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 
 
 # Provide a PEP 3115 compliant mechanism for class creation

--- a/Lib/types.py
+++ b/Lib/types.py
@@ -10,7 +10,6 @@ Define names for built-in types that aren't directly accessible as a builtin.
 try:
     from _types import *
 except ImportError:
-    import inspect
     import sys
 
     def _f(): pass
@@ -83,13 +82,14 @@ except ImportError:
     def enclose_lookup_special():
         _sentinel = object()
 
-        def lookup_special(object, name, default=_sentinel):
+        def lookup_special(object, name, default=_sentinel, /):
             """Lookup method name `name` on `object` skipping the instance
             dictionary.
 
             `name` must be a string. If the named special attribute does not exist,
             `default` is returned if provided, otherwise AttributeError is raised.
             """
+            import inspect
 
             cls = type(object)
             if not isinstance(name, str):
@@ -99,7 +99,7 @@ except ImportError:
             try:
                 descr = inspect.getattr_static(cls, name)
             except AttributeError:
-                if not default is _sentinel:
+                if default is not _sentinel:
                     return default
                 raise
             if hasattr(descr, "__get__"):
@@ -110,7 +110,7 @@ except ImportError:
 
     lookup_special = enclose_lookup_special()
 
-    del sys, inspect _f, _g, _C, _c, _ag, _cell_factory  # Not for export
+    del sys, enclose_lookup_special, _f, _g, _C, _c, _ag, _cell_factory  # Not for export
 
 
 # Provide a PEP 3115 compliant mechanism for class creation


### PR DESCRIPTION
@tanloong 

See https://discuss.python.org/t/expose-special-method-lookup-at-python-level/106236/11.
